### PR TITLE
Use project name as prefix for deployment bucket

### DIFF
--- a/{{cookiecutter.project_name}}/bin/_bootstrap
+++ b/{{cookiecutter.project_name}}/bin/_bootstrap
@@ -7,7 +7,7 @@ if [[ -z ${GITHUB_REPOSITORY+x} || -z $GITHUB_REPOSITORY ]]; then
   file=".bucket-name"
   if [ ! -f $file ]; then
     rand=$(ruby -r 'securerandom' -e 'puts(SecureRandom.hex[1,10])')
-    name="cookiecutter-ruby-demo-${rand}"
+    name="{% include "_cctmp/dash_name.txt" %}-deployment-${rand}"
     echo -n "$name" > "$file"
   else
     name=$(cat $file)


### PR DESCRIPTION
### Description

`./bin/bootstrap` create `cookiecutter-ruby-demo-****` as the deployment bucket. It's more relevant to see the bucket name with project pefix looking at s3 is better than creating a `cookiecutter-ruby-demo-***` bucket. 

### Changes

* Use the project name for creating deployment bucket.

